### PR TITLE
WorldManager Configuration Improvement

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -51,7 +51,7 @@
         "temp/": true,
         "Temp/": true
     },
-    "dotnet.defaultSolution": "Dojo.sln",
+    "dotnet.defaultSolution": "dojounity.sln",
     "rust-analyzer.linkedProjects": [
         "./Bindings/dojo.c/Cargo.toml"
     ]

--- a/Assets/Dojo/Prefabs/WorldManager.prefab
+++ b/Assets/Dojo/Prefabs/WorldManager.prefab
@@ -45,10 +45,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 85bbcaeafdf5e41c6a2f48ff65820b7d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  toriiUrl: http://localhost:8080
-  rpcUrl: http://localhost:5050
+  toriiUrl: 
+  rpcUrl: 
+  relayUrl: 
+  relayWebrtcUrl: 
   worldAddress: 
   synchronizationMaster: {fileID: 4477060482053654553}
+  dojoConfig: {fileID: 11400000, guid: 1d6a5fa48aab79f0084b213f6fc768c5, type: 2}
 --- !u!114 &4477060482053654553
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -63,7 +66,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   worldManager: {fileID: 1648136030876143075}
   limit: 100
-  models: []
   OnSynchronized:
     m_PersistentCalls:
       m_Calls: []

--- a/Assets/Dojo/Runtime/Config.meta
+++ b/Assets/Dojo/Runtime/Config.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a265271cc899c81a0be5a1edede52821
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Dojo/Runtime/Config/WorldManagerData.cs
+++ b/Assets/Dojo/Runtime/Config/WorldManagerData.cs
@@ -1,0 +1,19 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Dojo
+{
+    [CreateAssetMenu(fileName = "WorldManagerData", menuName = "ScriptableObjects/WorldManagerData", order = 2)]
+    public class WorldManagerData : ScriptableObject
+    {
+        [Header("RPC")]
+        public string toriiUrl = "http://localhost:8080";
+        public string rpcUrl = "http://localhost:5050";
+        public string relayUrl = "/ip4/127.0.0.1/tcp/9090";
+        public string relayWebrtcUrl;
+        public uint limit = 100;
+        [Header("World")]
+        public string worldAddress;
+    }
+}

--- a/Assets/Dojo/Runtime/Config/WorldManagerData.cs.meta
+++ b/Assets/Dojo/Runtime/Config/WorldManagerData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: faed63f2427f3ed83a42d16bb3e73e6d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Dojo/Runtime/Config/WorldManagerLocalConfig.asset
+++ b/Assets/Dojo/Runtime/Config/WorldManagerLocalConfig.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: faed63f2427f3ed83a42d16bb3e73e6d, type: 3}
+  m_Name: WorldManagerLocalConfig
+  m_EditorClassIdentifier: 
+  toriiUrl: http://localhost:8080
+  rpcUrl: http://localhost:5050
+  relayUrl: /ip4/127.0.0.1/tcp/9090
+  relayWebrtcUrl: /ip4/127.0.0.1/udp/9091/webrtc-direct/certhash/uEiDx-luHsovHTHPuU5qzNHCCFkYYpFPirTn2p7ZIFP0Dig
+  limit: 100
+  worldAddress: 0x28f5999ae62fec17c09c52a800e244961dba05251f5aaf923afabd9c9804d1a

--- a/Assets/Dojo/Runtime/Config/WorldManagerLocalConfig.asset.meta
+++ b/Assets/Dojo/Runtime/Config/WorldManagerLocalConfig.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1d6a5fa48aab79f0084b213f6fc768c5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Dojo/Runtime/WorldManager.cs
+++ b/Assets/Dojo/Runtime/WorldManager.cs
@@ -11,18 +11,33 @@ namespace Dojo
     public class WorldManager : MonoBehaviour
     {
         [Header("RPC")]
-        public string toriiUrl = "http://localhost:8080";
-        public string rpcUrl = "http://localhost:5050";
-        public string relayUrl = "/ip4/127.0.0.1/tcp/9090";
+        [HideInInspector]
+        public string toriiUrl;
+        [HideInInspector]
+        public string rpcUrl;
+        [HideInInspector]
+        public string relayUrl;
+        [HideInInspector]
         public string relayWebrtcUrl;
         [Header("World")]
+        [HideInInspector]
         public string worldAddress;
+        
         public SynchronizationMaster synchronizationMaster;
         public ToriiClient toriiClient;
         public ToriiWasmClient wasmClient;
 
+        [SerializeField] WorldManagerData dojoConfig;
+
+
         async void Awake()
         {
+            toriiUrl = dojoConfig.toriiUrl;
+            rpcUrl = dojoConfig.rpcUrl;
+            relayUrl = dojoConfig.relayUrl;
+            relayWebrtcUrl = dojoConfig.relayWebrtcUrl;
+            worldAddress = dojoConfig.worldAddress;
+
 #if UNITY_WEBGL && !UNITY_EDITOR
             wasmClient = new ToriiWasmClient(toriiUrl, rpcUrl, relayWebrtcUrl, worldAddress);
             await wasmClient.CreateClient();

--- a/Assets/Spawn And Move/GameManager.cs
+++ b/Assets/Spawn And Move/GameManager.cs
@@ -26,18 +26,15 @@ public class GameManager : MonoBehaviour
     private BurnerManager burnerManager;
     private Dictionary<FieldElement, string> spawnedBurners = new();
 
-    void Awake()
+    // Start is called before the first frame update
+    void Start()
     {
         var provider = new JsonRpcClient(worldManager.rpcUrl);
         var signer = new SigningKey(masterPrivateKey);
         var account = new Account(provider, signer, new FieldElement(masterAddress));
 
         burnerManager = new BurnerManager(provider, account);
-    }
 
-    // Start is called before the first frame update
-    void Start()
-    {
         worldManager.synchronizationMaster.OnEntitySpawned.AddListener(InitEntity);
         foreach (var entity in worldManager.Entities())
         {


### PR DESCRIPTION
# WorldManager Configuration Improvement

## Issue
The worldManager prefab currently embeds configuration data directly.
This makes it less flexible and readable, limiting the ability to switch configurations easily.

## Solution
Introduced a Scriptable Object ('WorldManagerData') to store configuration data for the worldManager. 
This enhances flexibility and readability by allowing the creation of different Scriptable Objects for diverse scenarios. 
For instance, it's now possible to create separate ScriptableObjects for offline and online configurations, making deployment configurations more versatile.

![image](https://github.com/dojoengine/dojo.unity/assets/87950451/68959f1c-e38e-4fc6-9f71-abcf8d19c261)


### Scriptable object fields
The ScriptableObject WorldManagerData mirrors all the fields present in the worldManager prefab. 

![image](https://github.com/dojoengine/dojo.unity/assets/87950451/6aa884c1-61e4-48cd-a0a4-1b32ed29c0fa)

> Creating an instance of the ScriptableObject is straightforward:

1. Navigate to Create in the Unity Editor.
2. Select ScriptableObjects.
3. Choose WorldManagerData from the options.

![image](https://github.com/dojoengine/dojo.unity/assets/87950451/c21f1cec-8b28-4132-a040-fa2111c9ce36)

