### PR TITLE
feat: update typed data to be snip 12 enum compliant

### DIFF
--- a/Assets/Spawn And Move/Models/PlayerConfig.cs
+++ b/Assets/Spawn And Move/Models/PlayerConfig.cs
@@ -54,6 +54,7 @@ public class PlayerConfig : ModelInstance
     // Start is called before the first frame update
     void Start()
     {
+        Debug.Log(JsonConvert.SerializeObject(new TypedData(Model)));
     }
 
     // Update is called once per frame


### PR DESCRIPTION
this will match the specification for how enums should be represented in a snip-12 typed data. however, for now, we do not completely match the enum types spec as we need to include all the types of all the variants but we only include the type of the selected variant