### PR TITLE
feat: add model update handler to sync master

### DIFF
--- a/Assets/Dojo/Runtime/SynchronizationMaster.cs
+++ b/Assets/Dojo/Runtime/SynchronizationMaster.cs
@@ -26,6 +26,7 @@ namespace Dojo
 
         public UnityEvent<List<GameObject>> OnSynchronized;
         public UnityEvent<GameObject> OnEntitySpawned;
+        public UnityEvent<ModelInstance> OnModelUpdated;
         public UnityEvent<ModelInstance> OnEventMessage;
 
         // Awake is called when the script instance is being loaded.
@@ -122,6 +123,7 @@ namespace Dojo
 
                 // update component with new model data
                 ((ModelInstance)component).OnUpdate(entityModel);
+                OnModelUpdated?.Invoke(model);
             }
         }
 


### PR DESCRIPTION
GM @Larkooo 

I added a handler for model updates on the SynchronizationMaster as I encountered some issues when using `ModelInstance.OnUpdated()`. I think having a handler is way more straightforward and easy to use.

The main issue with `OnUpdated` is that if the entity is spawned with partial models, we cannot register a listener for the yet non-instantiated models. 

Using `OnModelUpdated` allows us to receive an event even if the entity is already spawned, allowing us to register a listener to it.

Example use:
```Csharp
void Start()
{
  worldManager.synchronizationMaster.OnModelUpdated.AddListener(HandleUpdate);
}

void HandleUpdate(ModelInstance updatedModel)
{
  switch(updatedModel.GetType().Name) 
  {
    case "ns-Moves":
      OnMovesUpdated();
      break;
    case "ns-Position":
      OnPositionUpdated();
      break;
    default:
      Debug.LogWarning($"Received unknown model type: {updatedModel.GetType().Name}");
      break;
  }
}

void OnMovesUpdated() 
{
  // Handle moves update
}

void OnPositionUpdated() 
{
  // Handle position update
}
```
