### PR TITLE
Multiple input poseidon hash

### DIFF
--- a/Assets/Dojo/Plugins/WebGL/starknet.jslib
+++ b/Assets/Dojo/Plugins/WebGL/starknet.jslib
@@ -142,10 +142,12 @@ mergeInto(LibraryManager.library, {
     return buffer;
   },
   PoseidonHash: function (str) {
-    const hash = wasm_bindgen.poseidonHash(UTF8ToString(str));
+    const felts = JSON.parse(UTF8ToString(str));
+    const hash = wasm_bindgen.poseidonHash(felts);
     const bufferSize = lengthBytesUTF8(hash) + 1;
     const buffer = _malloc(bufferSize);
     stringToUTF8(hash, buffer, bufferSize);
     return buffer;
-  }
+  },
+  
 });

--- a/Assets/Dojo/Runtime/Starknet/StarknetInterop.cs
+++ b/Assets/Dojo/Runtime/Starknet/StarknetInterop.cs
@@ -236,5 +236,10 @@ namespace Dojo.Starknet
 
         [DllImport("__Internal")]
         public static extern string PoseidonHash(CString str);
+
+          public static string PoseidonHash(FieldElement[] felts)
+        {
+            return PoseidonHash(new CString(JsonConvert.SerializeObject(felts.Select(f => f.Hex()).ToArray())));
+        }
     }
 }


### PR DESCRIPTION
now the Poseidon hash has the ability to take in multiple inputs.

This was tested in windows (editor) and on WebGl